### PR TITLE
Fix calling to Object.assign with empty list of arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@engoo/rtcstats",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "dependencies": {

--- a/rtcstats.js
+++ b/rtcstats.js
@@ -173,6 +173,10 @@ function getStatsWithTrackSelector(pc) {
     Array.prototype.concat.apply([], pc.getLocalStreams().map(getStreamStats)),
     Array.prototype.concat.apply([], pc.getRemoteStreams().map(getStreamStats))
   )).then(function(statsDicts) {
+    if (statsDicts.length === 0) {
+      return {};
+    }
+
     return Object.assign.apply(null, statsDicts.map(map2obj));
   });
 }


### PR DESCRIPTION
Calling `Object.assign()` without arguments will cause an error:

```
Object.assign: argument is not an Object
```

Return an empty object in `getStatsWithTrackSelector` instead