### PR TITLE
Obfuscate fix

### DIFF
--- a/obfuscator.js
+++ b/obfuscator.js
@@ -25,6 +25,7 @@ Obfuscator.prototype.obfuscateCandidate = function (candidate) {
   var cand = SDPUtils.parseCandidate(candidate);
   if (cand.type !== 'relay') {
     cand.ip = this.obfuscateIP(cand.ip);
+    cand.address = this.obfuscateIP(cand.address);
   }
   if (cand.relatedAddress) {
     cand.relatedAddress = this.obfuscateIP(cand.relatedAddress);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "dependencies": {
-    "fast-json-patch": "^2.0.7"
+    "fast-json-patch": "^2.0.7",
+    "sdp": "^2.10.0"
   },
   "devDependencies": {
     "browserify": "^14.3.0",


### PR DESCRIPTION
rtcstats doesn't explicitly depend on `sdp` but it probably should. We manually added `sdp` as a dependency on frontend which is what this uses.

`sdp@2.9.0` broke compatibility with this commit https://github.com/otalk/sdp/commit/e6bcd1a1c1fb66d70ff3da553e0e36982c81d55b since we only obfuscate `ip`, the actual address gets reserialized. This fixes it so we obfuscate both.

It seems obfuscation was broken since 2019/2/14 since that's when we updated to 2.9.0 from 2.8.0.

As an aside, should we just vendor this into frontend? Alternatively, should we backport the ipaddr obfuscation fixes into this project?